### PR TITLE
Update destroy command function

### DIFF
--- a/terraformsh
+++ b/terraformsh
@@ -93,7 +93,7 @@ _cmd_plan_destroy () {
 }
 _cmd_destroy () {
     [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_init
-    _runcmd "$TERRAFORM" apply "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
+    _runcmd "$TERRAFORM" destroy "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
 }
 # Validate doesn't require 'init' to check the .tf files syntax, but it does
 # require init once it gets to the providers


### PR DESCRIPTION
In order to avoid executing and `apply` command to remote terraform cloud workspace when trying to destroy resources, changing the destroy function to use `destroy` sub command  instead of `apply` will avoid this issue when trying to destroy with `-P` flag which is the only way to deal with the remote backend since it currently does not support saving plan files which is the default behavior for `terraformsh` right now.